### PR TITLE
Fixed min error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ module.exports = function validate(params, schema, callback) {
       // anything goes!
       if (isNumAndUnderMin || lengthUnderMin || isCustom) {
         var msg = ''
-        msg += k + ' over max with value '
+        msg += k + ' under min with value '
         msg += lengthUnderMin? value.length : value
         msg += ' (min is ' + prop.min + ')'
         errors.push(RangeError(msg))


### PR DESCRIPTION
Changed error message for `min`. 

**Before:**
`"message": "customer.firstName over max with value 0 (min is 1)"`
**After:** 
`"message": "customer.firstName under min with value 0 (min is 1)"`