### PR TITLE
Allow type to be undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,8 +66,8 @@ module.exports = function validate(params, schema, callback) {
     var index = builtins.indexOf(prop.type)
     var notfound = index === -1
     var value = property(k)(params)
-     
-    if (notfound && (prop.type.min || prop.type.max)) {
+
+    if (prop.type && notfound && (prop.type.min || prop.type.max)) {
       rangesafe.push(prop.type)
     }
 

--- a/test/sanity-test.js
+++ b/test/sanity-test.js
@@ -12,7 +12,7 @@ test('optional callback win', t=> {
     'name': {required:true, type:String}
   }
   validate({name:'brian'}, schema, (err, data)=> {
-    if (err) { 
+    if (err) {
       t.fail(err)
     }
     else {
@@ -28,7 +28,7 @@ test('optional callback fail', t=> {
     'name': {required:true, type:String}
   }
   validate({}, schema, (err, data)=> {
-    if (err) { 
+    if (err) {
       t.ok(err, 'caught missing name')
     }
     else {
@@ -46,4 +46,20 @@ test('Function type check', t=> {
   var errors = validate({callback:'foo'}, schema)
   t.equal(errors.length, 1, 'nope not a fn')
   console.log(errors)
+})
+
+test('No type check', t=> {
+  t.plan(1)
+  var schema = {
+    'any': {required:true}
+  }
+  validate({any:'thing'}, schema, (err, data)=> {
+    if (err) {
+      t.fail(err)
+    }
+    else {
+      t.ok(data, 'there was a name')
+    }
+    console.log(err, data)
+  })
 })


### PR DESCRIPTION
The latest update caused breaks for us as we had some values that were required but their type wasn't strict.

I've also added a test case to cover this.