### PR TITLE
Add Trailing .0 To License Declaration.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "contract"
   ],
   "author": "Brian LeRoux <b@brian.io>",
-  "license": "Apache-2",
+  "license": "Apache-2.0",
   "dependencies": {
     "@smallwins/nodash": "^1.0.0"
   },


### PR DESCRIPTION
The SPDX licences must have changed slightly from the inception of this
package. The new Apache licences require a .0 for both v1 and v2. This
bumps this in the package.json.

Some build systems (Facebook's Rome) will hiccup/complain that these
licenses are not inline with those listed on the spdx.org listing.

SPDX listing:
https://spdx.org/licenses/

This seems like a super small issue but thought I would throw up a small pull request for it. It's also something that I am experiencing (while using Rome) with the Nodash package.

Hopefully this doesn't step on anyone's toes, thanks again all.